### PR TITLE
Fix authentication method issues

### DIFF
--- a/lastfm.el
+++ b/lastfm.el
@@ -514,7 +514,7 @@ VALUES."
   "Send and return the Last.fm request for METHOD.
 AUTH, PARAMS and VALUES are only passed allong to
 'lastfm--build-params'.  See the documentation for that method."
-  (let (resp (request-curl-options '("-d\"\"")))
+  (let (resp (request-curl-options '("-d" "")))
     (request lastfm--url
              :params (lastfm--build-params method auth params values)
              :parser 'buffer-string


### PR DESCRIPTION
When setting something as `-d ""`, both values have to be specified into the list, instead of only one string holding both.

Indeed related to the previous push and hair-pulling, the option that I added to curl was incorrectly coded, so while it worked for some methods, for the rest incorrect data were sent.